### PR TITLE
計算結果の出力コンポーネント

### DIFF
--- a/src/components/HelloWorld.vue
+++ b/src/components/HelloWorld.vue
@@ -80,6 +80,8 @@
     <!-- 計算結果の表示セクション -->
     <section class="results">
       <h2>計算結果</h2>
+      <button @click="calculateEqualPayment">均等割り勘</button>
+      <button @click="calculateIndividualPayment">個別割り勘</button>
       <ul>
         <li v-for="result in paymentResults" :key="result.participant">
           {{ result.participant }}: ¥{{ result.payment }}
@@ -142,7 +144,6 @@ export default {
     },
     calculatePayments() {
       let drinkCosts = {};
-      let totalDrinkCost = 0;
       for (const participant in this.consumptionRecords) {
         const drinks = this.consumptionRecords[participant];
         for (const drink in drinks) {
@@ -152,19 +153,32 @@ export default {
             drinkCosts[participant] = 0;
           }
           drinkCosts[participant] += drinkPrice * amount;
-          totalDrinkCost += drinkPrice * amount;
         }
       }
-      const foodCost = this.totalBillAmount - totalDrinkCost;
-      const foodCostPerPerson = foodCost / this.participants.length;
+
+      // 食べ物のコストを均等に分割
+      const foodCostPerPerson = (this.totalBillAmount - Object.values(drinkCosts).reduce((sum, cost) => sum + cost, 0)) / this.participants.length;
+
+      // 各参加者の支払い額を計算（飲料代 + 食べ物の均等割）
       this.paymentResults = this.participants.map(participant => ({
         participant,
         payment: (drinkCosts[participant] || 0) + foodCostPerPerson
       }));
+    },
+    calculateEqualPayment() {
+      const totalCostPerPerson = this.totalBillAmount / this.participants.length;
+      this.paymentResults = this.participants.map(participant => ({
+        participant,
+        payment: totalCostPerPerson
+      }));
+    },
+    calculateIndividualPayment() {
+      this.calculatePayments();
     }
   }
 }
 </script>
+
 
 <style>
 .home-container {

--- a/src/components/HelloWorld.vue
+++ b/src/components/HelloWorld.vue
@@ -125,7 +125,7 @@ export default {
     addDrink() {
       if (this.newDrink.name && this.newDrink.price > 0 && !this.drinks.some(d => d.name === this.newDrink.name)) {
         this.drinks.push({ ...this.newDrink });
-        this.newDrink = { name: '', price: 0 };
+        this.newDrink = { name: '', price: '' };
       }
     },
     removeDrink(drinkName) {
@@ -163,11 +163,12 @@ export default {
       // 各参加者の支払い額を計算（飲料代 + 食べ物の均等割）
       this.paymentResults = this.participants.map(participant => ({
         participant,
-        payment: (drinkCosts[participant] || 0) + foodCostPerPerson
+        payment: Math.ceil((drinkCosts[participant] || 0) + foodCostPerPerson)
       }));
+      this.showResults = true;
     },
     calculateEqualPayment() {
-      const totalCostPerPerson = this.totalBillAmount / this.participants.length;
+      const totalCostPerPerson = Math.ceil(this.totalBillAmount / this.participants.length);
       this.paymentResults = this.participants.map(participant => ({
         participant,
         payment: totalCostPerPerson

--- a/src/components/HelloWorld.vue
+++ b/src/components/HelloWorld.vue
@@ -1,7 +1,5 @@
 <template>
   <div class="home-container">
-    <h1>会計管理アプリ</h1>
-
     <!-- 参加者の追加セクション -->
     <section>
       <h2>参加者の追加</h2>
@@ -13,9 +11,9 @@
       <div class="participant-list">
         <h3>参加者一覧</h3>
         <ul>
-          <li v-for="(participant, index) in participants" :key="participant">
+          <li v-for="participant in participants" :key="participant">
             {{ participant }}
-            <button @click="removeParticipant(index)">削除</button>
+            <button @click="removeParticipant(participant)">削除</button>
           </li>
         </ul>
       </div>
@@ -35,6 +33,7 @@
         <ul>
           <li v-for="drink in drinks" :key="drink.name">
             {{ drink.name }} - ¥{{ drink.price }}
+            <button @click="removeDrink(drink.name)">削除</button>
           </li>
         </ul>
       </div>
@@ -44,21 +43,49 @@
     <section>
       <h2>飲料消費量の計算</h2>
       <div class="input-group">
-        <select>
-          <option selected>参加者を選択</option>
-          <!-- 参加者のリストがここに入る -->
+        <select v-model="selectedParticipant">
+          <option disabled value="">参加者を選択</option>
+          <option v-for="participant in participants" :key="participant" :value="participant">{{ participant }}</option>
         </select>
-        <input type="number" placeholder="消費量を入力(杯)" />
-        <button>計算を追加</button>
+        <select v-model="selectedDrink">
+          <option disabled value="">飲料を選択</option>
+          <option v-for="drink in drinks" :key="drink.name" :value="drink.name">{{ drink.name }}</option>
+        </select>
+        <input type="number" placeholder="消費量を入力(杯)" v-model.number="drinkAmount" />
+        <button @click="calculateConsumption">計算を追加</button>
+      </div>
+    </section>
+
+    <!-- 飲料消費記録の表示セクション -->
+    <section class="consumption-records">
+      <h2>飲料消費記録</h2>
+      <ul>
+        <li v-for="(records, participant) in consumptionRecords" :key="participant">
+          {{ participant }}: 
+          <span v-for="(amount, drink) in records" :key="drink">
+            {{ drink }} - {{ amount }} 杯
+          </span>
+        </li>
+      </ul>
+    </section>
+
+    <!-- お会計金額の入力セクション -->
+    <section>
+      <h2>お会計金額</h2>
+      <div class="input-group">
+        <input type="number" placeholder="お会計金額を入力" v-model.number="totalBillAmount" />
       </div>
     </section>
 
     <!-- 計算結果の表示セクション -->
     <section class="results">
       <h2>計算結果</h2>
-      <!-- 計算結果のリストがここに入る -->
+      <ul>
+        <li v-for="result in paymentResults" :key="result.participant">
+          {{ result.participant }}: ¥{{ result.payment }}
+        </li>
+      </ul>
     </section>
-
   </div>
 </template>
 
@@ -67,33 +94,73 @@ export default {
   name: 'HelloWorld',
   data() {
     return {
-      newParticipantName: '', // 新しい参加者名の入力用
-      participants: [], // 参加者リスト
-      newDrink: { // 新しい飲料の情報
+      newParticipantName: '',
+      participants: [],
+      newDrink: {
         name: '',
         price: ''
       },
-      drinks: [] // 飲料リスト
+      drinks: [],
+      selectedParticipant: '',
+      selectedDrink: '',
+      drinkAmount: '',
+      totalBillAmount: '',
+      consumptionRecords: {},
+      paymentResults: []
     };
   },
   methods: {
-    // 参加者を追加するメソッド
     addParticipant() {
-      if (this.newParticipantName) {
+      if (this.newParticipantName && !this.participants.includes(this.newParticipantName)) {
         this.participants.push(this.newParticipantName);
         this.newParticipantName = '';
       }
     },
-    removeParticipant(index) {
-      this.participants.splice(index, 1);
+    removeParticipant(participant) {
+      this.participants = this.participants.filter(p => p !== participant);
     },
-     // 飲料を追加するメソッド
     addDrink() {
-      if (this.newDrink.name && this.newDrink.price > 0) {
+      if (this.newDrink.name && this.newDrink.price > 0 && !this.drinks.some(d => d.name === this.newDrink.name)) {
         this.drinks.push({ ...this.newDrink });
-        this.newDrink.name = '';
-        this.newDrink.price = 0;
+        this.newDrink = { name: '', price: 0 };
       }
+    },
+    removeDrink(drinkName) {
+      this.drinks = this.drinks.filter(d => d.name !== drinkName);
+    },
+    calculateConsumption() {
+      if (this.selectedParticipant && this.selectedDrink && this.drinkAmount > 0) {
+        if (!this.consumptionRecords[this.selectedParticipant]) {
+          this.consumptionRecords[this.selectedParticipant] = {};
+        }
+        if (!this.consumptionRecords[this.selectedParticipant][this.selectedDrink]) {
+          this.consumptionRecords[this.selectedParticipant][this.selectedDrink] = 0;
+        }
+        this.consumptionRecords[this.selectedParticipant][this.selectedDrink] += this.drinkAmount;
+        this.calculatePayments();
+      }
+    },
+    calculatePayments() {
+      let drinkCosts = {};
+      let totalDrinkCost = 0;
+      for (const participant in this.consumptionRecords) {
+        const drinks = this.consumptionRecords[participant];
+        for (const drink in drinks) {
+          const amount = drinks[drink];
+          const drinkPrice = this.drinks.find(d => d.name === drink)?.price || 0;
+          if (!drinkCosts[participant]) {
+            drinkCosts[participant] = 0;
+          }
+          drinkCosts[participant] += drinkPrice * amount;
+          totalDrinkCost += drinkPrice * amount;
+        }
+      }
+      const foodCost = this.totalBillAmount - totalDrinkCost;
+      const foodCostPerPerson = foodCost / this.participants.length;
+      this.paymentResults = this.participants.map(participant => ({
+        participant,
+        payment: (drinkCosts[participant] || 0) + foodCostPerPerson
+      }));
     }
   }
 }
@@ -127,11 +194,12 @@ export default {
   border: 1px solid #ddd;
   padding: 1rem;
 }
-.results {
+
+.results,
+.consumption-records {
   margin-top: 2rem;
   padding: 1rem;
   background-color: #f7f7f7;
   border: 1px solid #ddd;
 }
-
 </style>

--- a/src/components/HelloWorld.vue
+++ b/src/components/HelloWorld.vue
@@ -82,11 +82,11 @@
       <h2>計算結果</h2>
       <button @click="calculateEqualPayment">均等割り勘</button>
       <button @click="calculateIndividualPayment">個別割り勘</button>
-      <ul>
+      <ul v-if="showResults">
         <li v-for="result in paymentResults" :key="result.participant">
           {{ result.participant }}: ¥{{ result.payment }}
         </li>
-      </ul>
+    </ul>
     </section>
   </div>
 </template>
@@ -107,6 +107,7 @@ export default {
       selectedDrink: '',
       drinkAmount: '',
       totalBillAmount: '',
+      showResults: false, // 計算結果の表示制御フラグ
       consumptionRecords: {},
       paymentResults: []
     };
@@ -171,9 +172,11 @@ export default {
         participant,
         payment: totalCostPerPerson
       }));
+      this.showResults = true;
     },
     calculateIndividualPayment() {
       this.calculatePayments();
+      this.showResults = true;
     }
   }
 }


### PR DESCRIPTION
- [x] 各人の飲料記録を出力
- [x] 飲料記録は1ユーザー1行で出力
- [x] 食料の費用も含めた会計金額の入力欄を作成する
- [x] 飲料記録を考慮して, 厳密な割り勘を計算する
- [x] 全体の飲料費用を均等に分割するオプションと、個々の消費量に基づいて分割するオプションを提供する
- [x] 支払金額は整数で表示する
- [x] 飲料の金額を入力するフィールドは, ボタンを押した後初期値(空文字)に戻す